### PR TITLE
[PR] fix Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,4 +17,4 @@ phonopy = "*"
 jupyter = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f7d7cc11e9883d61da29614c10bab6cb85e01e2caaf5f547e505d657bad2ed3"
+            "sha256": "ba485bff8afbb203e23950c2cfb39c8dad5449375a11431be9d08cf44975fe12"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6.7"
         },
         "sources": [
             {

--- a/test.sh
+++ b/test.sh
@@ -23,23 +23,23 @@ rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
 ./hdnnpy sym_func >/dev/null
 
 rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
-mpirun -np 4 ./hdnnpy sym_func >/dev/null
+mpirun -np 2 ./hdnnpy sym_func >/dev/null
 
 rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
 ./hdnnpy training --verbose >/dev/null
 
 rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
-mpirun -np 4 ./hdnnpy training --verbose >/dev/null
+mpirun -np 2 ./hdnnpy training --verbose >/dev/null
 
 rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
 ./hdnnpy param_search --verbose >/dev/null
 
 rm -rf ${debug_path}/{CrystalGa16N16,CrystalGa2N2,config_type.dill}
-mpirun -np 4 ./hdnnpy param_search --verbose >/dev/null
+mpirun -np 2 ./hdnnpy param_search --verbose >/dev/null
 
 ./hdnnpy training --verbose >/dev/null
 
-mpirun -np 4 ./hdnnpy training --verbose >/dev/null
+mpirun -np 2 ./hdnnpy training --verbose >/dev/null
 
 ./hdnnpy test >/dev/null
 


### PR DESCRIPTION
building python 3.7.1 requires latest OpenSSL, so change "python version" 3.7 -> 3.6.7 in Pipfile