### PR TITLE
Validate args of user input in vasp2xyz

### DIFF
--- a/scripts/vasp2xyz
+++ b/scripts/vasp2xyz
@@ -8,7 +8,10 @@ args = sys.argv
 
 # argv[0] contains all args
 if len(args) is not 3 + 1:
-    sys.stdout.write("Error: args should have 3 but has {}\n\nThe format should be \n\n $ vasp2xyz [CONFIG] [OUTCAR] [XYZFILE]\n\n".format(len(args)-1))
+    sys.stdout.write("Error: args should have 3 but has {}\n\n\
+                      The format should be \n\n \
+                      $ vasp2xyz [CONFIG] [OUTCAR] [XYZFILE]\n\n"
+                        .format(len(args)-1))
     sys.exit(1)
 
 config = args[1]

--- a/scripts/vasp2xyz
+++ b/scripts/vasp2xyz
@@ -5,14 +5,22 @@ import sys
 import ase.io
 
 args = sys.argv
+
+# argv[0] contains all args
+if len(args) is not 3 + 1:
+    sys.stdout.write("Error: args should have 3 but has {}\n\nThe format should be \n\n $ vasp2xyz [CONFIG] [OUTCAR] [XYZFILE]\n\n".format(len(args)-1))
+    sys.exit(1)
+
 config = args[1]
 input = args[2]
 output = args[3]
 
 images = []
+
 for atoms in ase.io.iread(input, index=':', format='vasp-out'):
     # stress = atoms.get_stress(voigt=False)
     # atoms.set_param_value('stress', stress)
     atoms.info['config_type'] = config + atoms.get_chemical_formula()
     images.append(atoms)
+
 ase.io.write(output, images, format='xyz')

--- a/scripts/vasp2xyz
+++ b/scripts/vasp2xyz
@@ -10,11 +10,11 @@ args = sys.argv
 if len(args) is not 3 + 1:
     sys.stdout.write("Error: args should have 3 but has {}\n\n\
                       The format should be \n\n \
-                      $ vasp2xyz [CONFIG] [OUTCAR] [XYZFILE]\n\n"
+                      $ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\n\n"
                         .format(len(args)-1))
     sys.exit(1)
 
-config = args[1]
+prefix = args[1]
 input = args[2]
 output = args[3]
 
@@ -23,7 +23,7 @@ images = []
 for atoms in ase.io.iread(input, index=':', format='vasp-out'):
     # stress = atoms.get_stress(voigt=False)
     # atoms.set_param_value('stress', stress)
-    atoms.info['config_type'] = config + atoms.get_chemical_formula()
+    atoms.info['config_type'] = prefix + atoms.get_chemical_formula()
     images.append(atoms)
 
 ase.io.write(output, images, format='xyz')


### PR DESCRIPTION
When users misses args, previous error looks like

```
Traceback (most recent call last):
  File "/Users/keisukeyamashita/.local/share/virtualenvs/HDNNP-D8nCws6U/bin/vasp2xyz", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/keisukeyamashita/Dropbox/go/src/github.com/ogura-edu/HDNNP/scripts/vasp2xyz", line 8, in <module>
    config = args[1]
IndexError: list index out of range
```

and it might be hard to find out what is wrong.

So added a script for validation.

Example

```
$ vasp2xyz Missing OneInput
```

The output is

```
Error: args should have 3 but has 2

The format should be

 $ vasp2xyz [CONFIG] [OUTCAR] [XYZFILE]
```

Its much clear error.

Thank you.