### PR TITLE
Fix validation error output

### DIFF
--- a/scripts/vasp2xyz
+++ b/scripts/vasp2xyz
@@ -8,9 +8,7 @@ args = sys.argv
 
 # argv[0] contains all args
 if len(args) is not 3 + 1:
-    sys.stdout.write("Error: args should have 3 but has {}\n\n\
-                      The format should be \n\n \
-                      $ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\n\n"
+    sys.stdout.write("""Error: args should have 3 but has {}\n\nThe format should be \n\n$ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\n\n"""
                         .format(len(args)-1))
     sys.exit(1)
 

--- a/scripts/vasp2xyz
+++ b/scripts/vasp2xyz
@@ -8,7 +8,13 @@ args = sys.argv
 
 # argv[0] contains all args
 if len(args) is not 3 + 1:
-    sys.stdout.write("""Error: args should have 3 but has {}\n\nThe format should be \n\n$ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\n\n"""
+    sys.stdout.write("""\
+Error: args should have 3 but has {}
+
+The format should be
+
+$ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\
+""".format(len(args)-1))
                         .format(len(args)-1))
     sys.exit(1)
 


### PR DESCRIPTION
I've forgot that for multiline output, I needed to process the string.

Recently: 

```
Error: args should have 3 but has 2

                     The format should be

                       $ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]

```

So, instead of adding more process to the string, I chose to use this.

```python
sys.stdout.write("""Error: args should have 3 but has {}\n\nThe format should be \n\n$ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]\n\n"""
                        .format(len(args)-1))
```

Now:

```
Error: args should have 3 but has 2

The format should be

$ vasp2xyz [PREFIX] [OUTCAR] [XYZFILE]
```

Thanks.