### PR TITLE
[PR] updated to version 0.4.0.dev

### DIFF
--- a/hdnnpy/_version.py
+++ b/hdnnpy/_version.py
@@ -1,3 +1,3 @@
 # coding=utf-8
 
-__version__ = '0.3.0.dev'
+__version__ = '0.4.0.dev'

--- a/hdnnpy/cli/conversion_application.py
+++ b/hdnnpy/cli/conversion_application.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+
+import datetime
+import socket
+import textwrap
+
+import chainer
+from traitlets import (CaselessStrEnum, Dict, Unicode)
+from traitlets.config import Application
+import yaml
+
+from hdnnpy import __version__
+from hdnnpy.cli.configurables import (DatasetConfig, ModelConfig, Path)
+from hdnnpy.model import MasterNNP
+from hdnnpy.preprocess import PREPROCESS
+from hdnnpy.utils import (pprint, pyyaml_path_constructor)
+
+
+class ConversionApplication(Application):
+    name = Unicode(u'hdnnpy convert')
+    description = 'Convert output files of training to required format.'
+
+    format = CaselessStrEnum(
+        ['lammps'],
+        default_value='lammps',
+        help='Name of the destination format.',
+        ).tag(config=True)
+    load_dir = Path(
+        default_value='output',
+        help='Path to directory to load training output files.',
+        ).tag(config=True)
+
+    aliases = Dict({
+        'format': 'ConversionApplication.format',
+        'load_dir': 'ConversionApplication.load_dir',
+        })
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.training_result = None
+        self.dataset_config = None
+        self.model_config = None
+
+    def initialize(self, argv=None):
+        self.parse_command_line(argv)
+
+        yaml.add_constructor('Path', pyyaml_path_constructor)
+        self.training_result = yaml.load(
+            (self.load_dir / 'training_result.yaml').open())
+        self.dataset_config = DatasetConfig(**self.training_result['dataset'])
+        self.model_config = ModelConfig(**self.training_result['model'])
+
+    def start(self):
+        tr = self.training_result
+        dc = self.dataset_config
+        mc = self.model_config
+
+        # load preprocesses
+        preprocesses = []
+        for (name, args, kwargs) in dc.preprocesses:
+            preprocess = PREPROCESS[name](*args, **kwargs)
+            preprocess.load(
+                self.load_dir / 'preprocess' / f'{name}.npz', verbose=False)
+            preprocesses.append(preprocess)
+        # load master nnp
+        master_nnp = MasterNNP(tr['training']['elements'], mc.layers)
+        chainer.serializers.load_npz(
+            self.load_dir / 'master_nnp.npz', master_nnp)
+
+        if self.format == 'lammps':
+            self.dump_for_lammps(preprocesses, master_nnp)
+
+    def dump_for_lammps(self, preprocesses, master_nnp):
+        dc = self.dataset_config
+        potential_file = self.load_dir / 'lammps.nnp'
+        with potential_file.open('w') as f:
+            # information
+            now = datetime.datetime.now()
+            machine = socket.gethostname()
+            pprint(f'''
+            # Created by hdnnpy {__version__} ({now}).
+            # All parameters are read from [{machine}] {self.load_dir}.
+            # Ref: https://github.com/ogura-edu/HDNNP
+            ''', stream=f)
+
+            # descriptor
+            pprint(f'''
+            # {dc.descriptor} parameters
+            {len(dc.parameters)}
+            ''', stream=f)
+            for name, params in dc.parameters.items():
+                params_str = ('\n'+' '*16).join([' '.join(map(str, row))
+                                                 for row in params])
+                pprint(f'''
+                {name} {len(params)}
+                {params_str}
+                ''', stream=f)
+
+            # preprocess
+            pprint(f'''
+            # pre-processing parameters
+            {len(preprocesses)}
+            ''', stream=f)
+            for preprocess in preprocesses:
+                pprint(f'''
+                {preprocess.name}
+
+                {textwrap.indent(
+                    textwrap.dedent(preprocess.dump_params()), ' '*16)}
+                ''', stream=f)
+
+            # model
+            pprint(f'''
+            # neural network parameters
+            {len(master_nnp[0])}
+
+            {textwrap.indent(
+                textwrap.dedent(master_nnp.dump_params()), ' '*12)}
+            ''', stream=f)

--- a/hdnnpy/cli/main.py
+++ b/hdnnpy/cli/main.py
@@ -7,6 +7,7 @@ import sys
 from traitlets import Unicode
 from traitlets.config import Application
 
+from hdnnpy.cli.conversion_application import ConversionApplication
 from hdnnpy.cli.prediction_application import PredictionApplication
 from hdnnpy.cli.training_application import TrainingApplication
 from hdnnpy.utils import MPI
@@ -15,9 +16,14 @@ from hdnnpy.utils import MPI
 class HDNNPApplication(Application):
     name = Unicode(u'hdnnpy')
 
-    classes = [PredictionApplication, TrainingApplication]
+    classes = [
+        ConversionApplication,
+        PredictionApplication,
+        TrainingApplication,
+        ]
 
     subcommands = {
+        'convert': (ConversionApplication, ConversionApplication.description),
         'predict': (PredictionApplication, PredictionApplication.description),
         'train': (TrainingApplication, TrainingApplication.description),
         }
@@ -26,7 +32,8 @@ class HDNNPApplication(Application):
         if MPI.rank != 0:
             sys.stdout = Path(os.devnull).open('w')
         assert sys.argv[1] in self.subcommands, \
-            'Only `hdnnpy train` and `hdnnpy predict` are available.'
+            'Only `hdnnpy train` and `hdnnpy predict` `hdnnpy convert` are' \
+            ' available.'
         super().initialize(argv)
 
 

--- a/hdnnpy/model/models.py
+++ b/hdnnpy/model/models.py
@@ -187,6 +187,34 @@ class MasterNNP(chainer.ChainList):
         """
         super().__init__(*[SubNNP(element, layers) for element in elements])
 
+    def dump_params(self):
+        """Dump its own parameters as :obj:`str`.
+
+        Returns:
+            str: Formed parameters.
+        """
+        params_str = ''
+        for nnp in self:
+            element = nnp.element
+            depth = len(nnp)
+            for i in range(depth):
+                weight = getattr(nnp, f'fc_layer{i}').W.data
+                bias = getattr(nnp, f'fc_layer{i}').b.data
+                activation = getattr(nnp, f'activation_function{i}').__name__
+                weight_str = ('\n'+' '*16).join([' '.join(map(str, row))
+                                                 for row in weight.T])
+                bias_str = ' '.join(map(str, bias))
+
+                params_str += f'''
+                {element} {i} {weight.shape[1]} {weight.shape[0]} {activation}
+                # weight
+                {weight_str}
+                # bias
+                {bias_str}
+                '''
+
+        return params_str
+
 
 class SubNNP(chainer.Chain):
     """Feed-forward neural network representing one element or atom."""

--- a/hdnnpy/preprocess/pca.py
+++ b/hdnnpy/preprocess/pca.py
@@ -81,6 +81,30 @@ class PCA(PreprocessBase):
 
         return dataset
 
+    def dump_params(self):
+        """Dump its own parameters as :obj:`str`.
+
+        Returns:
+            str: Formed parameters.
+        """
+        params_str = ''
+        for element in self._elements:
+            transform = self._transform[element]
+            mean = self._mean[element]
+            transform_str = ('\n'+' '*12).join([' '.join(map(str, row))
+                                                for row in transform.T])
+            mean_str = ' '.join(map(str, mean))
+
+            params_str += f'''
+            {element} {transform.shape[1]} {transform.shape[0]}
+            # transformation matrix
+            {transform_str}
+            # mean
+            {mean_str}
+            '''
+
+        return params_str
+
     def load(self, file_path, verbose=True):
         """Load internal parameters for each element.
 

--- a/hdnnpy/preprocess/preprocess_base.py
+++ b/hdnnpy/preprocess/preprocess_base.py
@@ -36,6 +36,15 @@ class PreprocessBase(ABC):
         pass
 
     @abstractmethod
+    def dump_params(self):
+        """Dump its own parameters as :obj:`str`.
+
+        This is abstract method.
+        Subclass of this base class have to override.
+        """
+        pass
+
+    @abstractmethod
     def load(self, *args, **kwargs):
         """Load internal parameters for each element.
 

--- a/hdnnpy/preprocess/scaling.py
+++ b/hdnnpy/preprocess/scaling.py
@@ -84,6 +84,32 @@ class Scaling(PreprocessBase):
 
         return dataset
 
+    def dump_params(self):
+        """Dump its own parameters as :obj:`str`.
+
+        Returns:
+            str: Formed parameters.
+        """
+        params_str = (f'''
+            # target range
+            {self._target_max} {self._target_min}
+            ''')
+        for element in self._elements:
+            max_ = self._max[element]
+            min_ = self._min[element]
+            max_str = ' '.join(map(str, max_))
+            min_str = ' '.join(map(str, min_))
+
+            params_str += f'''
+            {element} {max_.shape[0]}
+            # max
+            {max_str}
+            # min
+            {min_str}
+            '''
+
+        return params_str
+
     def load(self, file_path, verbose=True):
         """Load internal parameters for each element.
 
@@ -131,7 +157,7 @@ class Scaling(PreprocessBase):
             mask = np.array(elemental_composition) == element
             X = data[:, mask].reshape(-1, n_feature)
             self._elements.add(element)
-            self._max[element] = X.max(axis=0, dtype=np.float32)
-            self._min[element] = X.min(axis=0, dtype=np.float32)
+            self._max[element] = X.max(axis=0)
+            self._min[element] = X.min(axis=0)
             if verbose:
                 pprint(f'Initialized Scaling parameters for {element}')

--- a/hdnnpy/preprocess/standardization.py
+++ b/hdnnpy/preprocess/standardization.py
@@ -65,6 +65,29 @@ class Standardization(PreprocessBase):
 
         return dataset
 
+    def dump_params(self):
+        """Dump its own parameters as :obj:`str`.
+
+        Returns:
+            str: Formed parameters.
+        """
+        params_str = ''
+        for element in self._elements:
+            mean = self._mean[element]
+            std = self._std[element]
+            mean_str = ' '.join(map(str, mean))
+            std_str = ' '.join(map(str, std))
+
+            params_str += f'''
+            {element} {mean.shape[0]}
+            # mean
+            {mean_str}
+            # standard deviation
+            {std_str}
+            '''
+
+        return params_str
+
     def load(self, file_path, verbose=True):
         """Load internal parameters for each element.
 
@@ -112,7 +135,7 @@ class Standardization(PreprocessBase):
             mask = np.array(elemental_composition) == element
             X = data[:, mask].reshape(-1, n_feature)
             self._elements.add(element)
-            self._mean[element] = X.mean(axis=0, dtype=np.float32)
-            self._std[element] = X.std(axis=0, ddof=1, dtype=np.float32)
+            self._mean[element] = X.mean(axis=0)
+            self._std[element] = X.std(axis=0, ddof=1)
             if verbose:
                 pprint(f'Initialized Standardization parameters for {element}')

--- a/hdnnpy/utils.py
+++ b/hdnnpy/utils.py
@@ -6,13 +6,17 @@ __all__ = [
     'MPI',
     'mkdir',
     'pprint',
+    'pyyaml_path_constructor',
+    'pyyaml_path_representer',
     'recv_chunk',
     'send_chunk',
     ]
 
+from pathlib import Path
 import pickle
 from pprint import pprint as pretty_print
 import sys
+import textwrap
 
 from mpi4py import MPI as MPI4PY
 
@@ -49,6 +53,7 @@ def pprint(data=None, flush=True, **options):
     """
     if data is None:
         data = ''
+    data = textwrap.dedent(data)
     if isinstance(data, list) or isinstance(data, dict):
         pretty_print(data, **options)
     else:
@@ -57,6 +62,15 @@ def pprint(data=None, flush=True, **options):
         print(data, **options)
     if flush:
         sys.stdout.flush()
+
+
+def pyyaml_path_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    return Path(value)
+
+
+def pyyaml_path_representer(dumper, instance):
+    return dumper.represent_scalar('Path', f'{instance}')
 
 
 def recv_chunk(source, max_buf_len=256 * 1024 * 1024):


### PR DESCRIPTION
added 'convert' subcommand which does convert output files of training
  into specific format file.
  currently, only for dumping parameters used for HDNNP-LAMMPS program
added `ConversionApplication` class
added `dump_params` method to some classes
moved helper methods of `pyyaml` package into hdnnpy/utils.py
bugfixed: hdnnpy/preprocess/scaling.py