### PR TITLE
updated to 0.4.1.dev

### DIFF
--- a/hdnnpy/_version.py
+++ b/hdnnpy/_version.py
@@ -1,3 +1,3 @@
 # coding=utf-8
 
-__version__ = '0.4.0.dev'
+__version__ = '0.4.1.dev'

--- a/hdnnpy/cli/training_application.py
+++ b/hdnnpy/cli/training_application.py
@@ -257,7 +257,9 @@ class TrainingApplication(Application):
                 with manager:
                     trainer.run()
 
-        chainer.serializers.save_npz(tc.out_dir / 'master_nnp.npz', master_nnp)
+        MPI.rank == 0:
+            chainer.serializers.save_npz(
+                tc.out_dir / 'master_nnp.npz', master_nnp)
 
         return result
 


### PR DESCRIPTION
bugfix: changed to save `masternnp` from only root MPI process