### PR TITLE
Issue 265

### DIFF
--- a/hdnnpy/cli/prediction_application.py
+++ b/hdnnpy/cli/prediction_application.py
@@ -70,7 +70,8 @@ class PredictionApplication(Application):
         self.load_config_file(self.config_file)
         self.prediction_config = PredictionConfig(config=self.config)
 
-        yaml.add_constructor('Path', pyyaml_path_constructor)
+        yaml.add_constructor('Path', pyyaml_path_constructor, Loader=yaml.FullLoader)
+        """Add <Loader=yaml.FullLoader> for issue-265: enabling to use pyyaml 5.1x """
         training_result = yaml.load(
             (self.prediction_config.load_dir / 'training_result.yaml').open())
         self.dataset_config = DatasetConfig(**training_result['dataset'])

--- a/hdnnpy/preprocess/pca.py
+++ b/hdnnpy/preprocess/pca.py
@@ -117,7 +117,8 @@ class PCA(PreprocessBase):
             verbose (bool, optional): Print log to stdout.
         """
         if MPI.rank == 0:
-            ndarray = np.load(file_path)
+            ndarray = np.load(file_path, allow_pickle=True)
+            """Add <allow_pickle=True> for issue-265: enabling to use numpy 1.16.3 or later """
             self._elements = ndarray['elements'].item()
             self._n_components = ndarray['n_components'].item()
             self._mean = {element: ndarray[f'mean:{element}']


### PR DESCRIPTION
2 files are updated for fixing issue #265
1. /HDNNP/hdnnpy/cli/prediction_application.py
  Add parameter <Loader=yaml.FullLoader> to yaml.add_constructor for enabling to use pyyaml 5.1x
2. /HDNNP/hdnnpy/preprocess/pca.py
  Add parameter <allow_pickle=True> to np.load for enabling to use numpy 1.16.3 or later