### PR TITLE
[PR] Bugfix/symmetry function

### DIFF
--- a/hdnnpy/dataset/atomic_structure.py
+++ b/hdnnpy/dataset/atomic_structure.py
@@ -163,7 +163,6 @@ class AtomicStructure(object):
             'element_indices': [np.searchsorted(elem, range(len(elements)))
                                 for elem in elem_list],
             'i_positions': r_i_list,
-            'i_indices': i_list,
             'i_indices': [np.searchsorted([i], range(len(symbols)))
                           for i in i_list],
             'j_positions': r_j_list,

--- a/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
+++ b/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
@@ -129,12 +129,14 @@ class SymmetryFunctionDataset(DescriptorDatasetBase):
                 yield F.stack([F.stack(g) for g in G])
 
             n_atom = len(G[0])
-            r = []
-            j_indices = []
-            for r_, j_idx in structure.get_neighbor_info(
-                    Rc, ['distance_vector', 'j_indices']):
-                r.append(r_)
-                j_indices.append(j_idx)
+            diff_positions = []
+            diff_indices = []
+            for i_pos, i_idx, j_pos, j_idx in structure.get_neighbor_info(
+                    Rc,
+                    ['i_positions', 'i_indices', 'j_positions', 'j_indices']
+                ):
+                diff_positions.extend([i_pos, j_pos])
+                diff_indices.extend([i_idx, j_idx])
 
             differentiate_more = self._order > 1
             with chainer.using_config('enable_backprop', differentiate_more):
@@ -142,12 +144,25 @@ class SymmetryFunctionDataset(DescriptorDatasetBase):
                 for g in G:
                     with chainer.force_backprop_mode():
                         grad = chainer.grad(
-                            g, r, enable_double_backprop=differentiate_more)
-                    dg = [F.concat([F.sum(dg_, axis=0) for dg_
-                                    in F.split_axis(grad_, j_idx[1:],
-                                                    axis=0)],
-                                   axis=0)
-                          for grad_, j_idx in zip(grad, j_indices)]
+                            g, diff_positions,
+                            enable_double_backprop=differentiate_more)
+                    dg = [
+                        # by center atom itself
+                        F.concat([
+                            F.sum(dg_, axis=0)
+                            for dg_ in F.split_axis(
+                                grad[2*i], diff_indices[2*i][1:], axis=0
+                                )
+                            ], axis=0)
+                        # by neighbor atoms
+                        + F.concat([
+                            F.sum(dg_, axis=0)
+                            for dg_ in F.split_axis(
+                                grad[2*i+1], diff_indices[2*i+1][1:], axis=0
+                                )
+                            ], axis=0)
+                        for i in range(n_atom)
+                    ]
                     dG.append(dg)
                 yield F.stack([F.stack(dg) for dg in dG])
 
@@ -156,16 +171,28 @@ class SymmetryFunctionDataset(DescriptorDatasetBase):
                 d2G = []
                 for dg in dG:
                     d2g = []
-                    for i in range(3 * n_atom):
+                    for j in range(3 * n_atom):
                         with chainer.force_backprop_mode():
                             grad = chainer.grad(
-                                [dg_[i] for dg_ in dg], r,
+                                [dg_[j] for dg_ in dg], diff_positions,
                                 enable_double_backprop=differentiate_more)
-                        d2g_ = [F.concat([F.sum(d2g_, axis=0) for d2g_
-                                          in F.split_axis(grad_, j_idx[1:],
-                                                          axis=0)],
-                                         axis=0)
-                                for grad_, j_idx in zip(grad, j_indices)]
+                        d2g_ = [
+                            # by center atom itself
+                            F.concat([
+                                F.sum(d2g_, axis=0)
+                                for d2g_ in F.split_axis(
+                                    grad[2*i], diff_indices[2*i][1:], axis=0
+                                    )
+                                ], axis=0)
+                            # by neighbor atoms
+                            + F.concat([
+                                F.sum(d2g_, axis=0)
+                                for d2g_ in F.split_axis(
+                                    grad[2*i+1], diff_indices[2*i+1][1:], axis=0
+                                    )
+                                ], axis=0)
+                            for i in range(n_atom)
+                        ]
                         d2g.append(d2g_)
                     d2G.append(d2g)
                 yield F.stack([F.stack([F.stack(d2g_) for d2g_ in d2g])

--- a/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
+++ b/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
@@ -166,6 +166,7 @@ class SymmetryFunctionDataset(DescriptorDatasetBase):
                     dG.append(dg)
                 yield F.stack([F.stack(dg) for dg in dG])
 
+            # d2G code is not tested yet
             differentiate_more = self._order > 2
             with chainer.using_config('enable_backprop', differentiate_more):
                 d2G = []

--- a/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
+++ b/hdnnpy/dataset/descriptor/symmetry_function_dataset.py
@@ -213,8 +213,8 @@ class SymmetryFunctionDataset(DescriptorDatasetBase):
                  * ang
                  * F.expand_dims(F.exp(-eta*R**2) * fc, axis=1)
                  * F.expand_dims(F.exp(-eta*R**2) * fc, axis=0))
-            triu = np.triu(np.ones_like(cos.data), k=1)
-            g = F.where(triu.astype(np.bool), g, triu)
+            mask = 1 - np.eye(cos.data.shape[0], dtype=np.float32)
+            g = F.where(mask.astype(np.bool), g, mask)
             g = [F.sum(g__)
                  for j, g_
                  in enumerate(F.split_axis(g, element_indices[1:], axis=0))


### PR DESCRIPTION
ディスカッションで見つけたバグを修正し、G・dG共に正解データと一致することを確認しました。

しかし、サンプルデータ（64原子、21構造）におけるG・dGの計算時間が大きく増加してしまったため、その部分の改善が新しい課題として挙げられます。

- 修正前：1m30s 程度
- 修正後：2m30s 程度